### PR TITLE
[CONAN] Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       dist: trusty
       language: cpp
       compiler: gcc
-      env: TARGET=linux_gcc CONAN_COMPILER='gcc' CONAN_COMPILER_VERSION='5.2'
+      env: TARGET=linux_gcc CONAN_COMPILER='gcc' CONAN_COMPILER_VERSION='5.4'
 
     - os: linux
       sudo: required

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,8 @@ before_build:
   - cmd: set "args=-DBUILD_CLIENT=1 -DBUILD_SERVER=1 -DBUILD_MASTER=1 -DBUILD_TEST=1 -DCREATE_PACKAGE=1"
   # Only deploy a bundle with the media folder if the branch is master (and its not a pr)(and its a Release build):
 #  - cmd: if "%configuration%"=="Release" if "%APPVEYOR_REPO_BRANCH%"=="master" if defined APPVEYOR_PULL_REQUEST_NUMBER set "args=%args% -DPACKAGE_INCLUDE_MEDIA=1"
-  - cmd: conan install .. --scope build_all=1 --scope create_package=1 --build=missing -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=%runtime_str% -s arch=%arch_str% -s build_type=%configuration% 
+  - cmd: conan remote add inexor https://api.bintray.com/conan/inexorgame/inexor-conan --insert
+  - cmd: conan install .. --scope build_all=1 --scope create_package=1 --build=missing -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=%runtime_str% -s arch=%arch_str% -s build_type=%configuration%
   - cmd: cmake .. -G "%CMAKE_GENERATOR_NAME%" %args% -DCPACK_GENERATOR="ZIP"
   #"NSIS;7Z"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ init:
 
 # scripts that run after cloning repository
 install:
-  - appveyor-retry choco install doxygen.portable
   - cmd: python -m pip install conan
   - cmd: set "MAIN_FOLDER=C:\projects\inexor-game"
   - cmd: cd %MAIN_FOLDER%

--- a/dependencies.py
+++ b/dependencies.py
@@ -1,21 +1,22 @@
-requires = (("InexorGlueGen/0.6.0alpha@inexorgame/testing"),
+requires = (("InexorGlueGen/0.6.0alpha@inexorgame/stable"),
             ("Protobuf/3.1.0@inexorgame/stable"),
             ("gRPC/1.1.0-dev@inexorgame/stable"),
-            ("doxygen/1.8.13@inexorgame/testing"),
-            ("Boost/1.64.0@inexorgame/stable"),
+            ("doxygen/1.8.13@inexorgame/stable"),
+            ("Boost/1.64.0@lasote/stable"),
             ("RapidJSON/1.0.2@inexorgame/stable"),
             ("zlib/1.2.11@lasote/stable"),
-            ("gtest/1.7.0@lasote/stable"),
+            ("gtest/1.8.0@lasote/stable"),
             ("ENet/1.3.13@inexorgame/stable"),
             ("spdlog/0.10.0@memsharded/stable"),
-            ("SDL2/2.0.5@lasote/stable"),
+            ("SDL2/2.0.5@lasote/testing"),  # not self-contained
             ("SDL2_image/2.0.1@lasote/stable"),
-            ("CEF/3.2704.1424.gc3f0a5b@a_teammate/testing")
+            ("CEF/3.2704.1424.gc3f0a5b@inexorgame/testing") # not self-contained
         )
 
 options = '''
   zlib:shared=False
   gtest:shared=False
+  gtest:no_gmock=True
   ENet:shared=False
   Boost:shared=False
   SDL2:shared=False

--- a/tool/create_visual_studio2015_project.bat
+++ b/tool/create_visual_studio2015_project.bat
@@ -2,5 +2,6 @@
 cd %~dp0..
 mkdir build
 cd build
+conan remote add inexor https://api.bintray.com/conan/inexorgame/inexor-conan --insert
 conan install .. --build=missing -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=MTd -s build_type=Debug
 conan build ..

--- a/tool/create_visual_studio2017_project.bat
+++ b/tool/create_visual_studio2017_project.bat
@@ -2,5 +2,6 @@
 cd %~dp0..
 mkdir build
 cd build
+conan remote add inexor https://api.bintray.com/conan/inexorgame/inexor-conan --insert
 conan install .. --build=missing -s compiler="Visual Studio" -s compiler.version=15 -s compiler.runtime=MTd -s build_type=Debug
 conan build ..

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -67,6 +67,7 @@ upload() {
 
 install_wily_repo() {
   echo -e "\ndeb http://archive.ubuntu.com/ubuntu wily "{main,multiverse,universe,restricted} >> /etc/apt/sources.list
+  echo -e "\ndeb http://archive.ubuntu.com/ubuntu zesty "{main,multiverse,universe,restricted} >> /etc/apt/sources.list
 }
 
 install_tool() {
@@ -111,7 +112,7 @@ install_linux_clang() {
 }
 install_linux_gcc() {
   install_linux
-  apt-get -y -t wily install gcc-5 g++-5
+  apt-get -y -t zesty install gcc-5 g++-5
 }
 install_apidoc() {
   apt-get update
@@ -201,11 +202,11 @@ create_tag() {
       "Skipping tag creation, because this build\n" \
       "got triggered by a tag.\n" \
       "===============\n"
-  elif [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then 
+  elif [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
     # direct push to master
 
     export new_version=$(incremented_version)
-    
+
     git config --global user.email "travis@travis-ci.org"
     git config --global user.name "Travis"
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -84,7 +84,7 @@ install_linux() {
   install_tool
 
   apt-get -y -t wily install --only-upgrade libfontconfig1
-  apt-get -y -t wily install build-essential binutils doxygen nasm
+  apt-get -y -t wily install build-essential binutils nasm
   python -m pip install conan
 
   # upgrade cmake

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -228,6 +228,7 @@ build() {
   (
     mkcd "/tmp/inexor-build"
     conan
+    conan remote add inexor https://api.bintray.com/conan/inexorgame/inexor-conan --insert
     echo "executed conan install "$gitroot" --scope build_all=1 --scope create_package=1 --build=missing -s compiler=$CONAN_COMPILER -s compiler.version=$CONAN_COMPILER_VERSION -s compiler.libcxx=libstdc++11"
     conan install "$gitroot" --scope build_all=1 --scope create_package=1  --build=missing -s compiler="$CONAN_COMPILER" -s compiler.version="$CONAN_COMPILER_VERSION" -s compiler.libcxx="libstdc++11"
     conan build "$gitroot"


### PR DESCRIPTION
 * Switch Boost back to lasote's package (we don't want to maintain it permanently)
 * Update gtest to 1.8.0 and exclude gmock, to fix GCC 5.4 under some circumstances
   * also excluding stuff we don't need = always good
 * GlueGen switched to stable, SDL & CEF switched to testing
   * why => https://github.com/inexorgame/inexor-core/issues/415#issuecomment-309252210

Since this causes that we have packages for all recipes for all platforms/compilers/configs we do support except SDL and CEF, the build time goes down dramatically, e.g. in Travis it only takes 20 minutes now vs 30 minutes. In AppVeyor it should be even more saved time, but I didn't test it.

@a-teammate  this CEF version is now the latest from our repository, do you have still problems with this version?
