### PR TITLE
Containerize CI, Conan packages building triggering and more...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ node_modules/
 
 # This file gets generated.
 dependencies.md
+
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,61 +1,179 @@
-language: c++
-sudo: required
-dist: trusty
+###########################
+####### README FIRST! #####
+###########################
+# This file should only be edited in our main repository (inexor-core)
+# You are doing something wrong
+# if you are trying to edit this file in the master branch of ci-prebuilds.
+#
+# Our automation is grabbing the version of this file from our main repository
+# and commit it with automatic changes to ci-prebuilds
+# and only when Conan dependencies are actually changed
+# in order to not cause unnecessary rebuilds.
+#
+# The ci-prebuilds version will have un-comment every line starting with #CI(followed by an empty space)
+# e.g. #CI echo this only gets executed in ci-prebuilds
+#
+# The ci-prebuilds version will have every line removed containing #CIDELETE
+# e.g. #CIDELETE this line is not visible in ci-prebuilds aka. won't get executed
+#
 
 notifications:
   email:
     on_success: never
     on_failure: change
 
-env:
-  global:
-    - secure: UUtdYLhd9+cY+bMrcRvvtjmsQBqM5L9zgzyLeQZLMmmWbHwLsfpQask9A8eD1oc1K1o0tYmK+Qk1flxNTbnUtlryPNgJxJ95a/TwLl1P9yN6plMleNbuwMs5dyS9VnmcK3LzDFuoje/9rtX2seNR2PW2EJSvPz20ENaT693Kfa8=
-    - secure: G8rRE17KDx83crRLQSEkIyvMbXlbpKDvIYoKE+y9Bg3qu79tsB/RrNdo6OGHx4x3KhBGpuo4NdN/4FAGS599P4W+KN3kNr9VFSCMJhJK59+KkYfGq2rX1oGDhB4B1xjVk0tj6bFIJ333hVLEYFviIKYxRSZfnKa0RmgBJZbvMfs=
+git:
+  depth: 15
 
-matrix:
+jobs:
   include:
-    - os: linux
-      sudo: required
-      dist: trusty
-      language: cpp
-      compiler: clang
-      env: TARGET=linux_clang CONAN_COMPILER='clang' CONAN_COMPILER_VERSION='3.9'
+  # We run the following jobs in our main repository:    #CIDELETE
+    - stage: Conan                                       #CIDELETE
+      os: linux                                          #CIDELETE
+      dist: trusty                                       #CIDELETE
+      sudo: false                                        #CIDELETE
+      language: cpp                                      #CIDELETE
+      env: docker_tag="NODOCKER" conan_prebuilds="true"  #CIDELETE
+    - stage: Testing                                     #CIDELETE
+      os: linux                                          #CIDELETE
+      dist: trusty                                       #CIDELETE
+      sudo: required                                     #CIDELETE
+      language: cpp                                      #CIDELETE
+      compiler: clang                                    #CIDELETE
+      services:                                          #CIDELETE
+        - docker                                         #CIDELETE
+      env: CMAKE_CC="clang-4.0" CMAKE_CXX="clang++-4.0" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="4.0" TARGET=linux_clang docker_tag="optimization" NIGHTLY="true" #CIDELETE
+    - os: linux                                          #CIDELETE
+      dist: trusty                                       #CIDELETE
+      sudo: required                                     #CIDELETE
+      language: cpp                                      #CIDELETE
+      compiler: gcc                                      #CIDELETE
+      services:                                          #CIDELETE
+        - docker                                         #CIDELETE
+      env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="7.2" TARGET=linux_gcc docker_tag="gcc070clang040" NIGHTLY="true" #CIDELETE
+    - stage: "Create GitHub Tag"                         #CIDELETE
+      if: branch = master AND tag is blank AND fork is false AND type != pull_request #CIDELETE
+      os: linux                                          #CIDELETE
+      sudo: false                                        #CIDELETE
+      dist: trusty                                       #CIDELETE
+      language: cpp                                      #CIDELETE
+      env: docker_tag="NODOCKER" TARGET=new_version_tagger #CIDELETE
+      git:                                               #CIDELETE
+        submodules: false                                #CIDELETE
+      branches:                                          #CIDELETE
+        only:                                            #CIDELETE
+          - master                                       #CIDELETE
+    #- os: linux                                         #CIDELETE
+      #sudo: false                                       #CIDELETE
+      #dist: trusty                                      #CIDELETE
+      #language: cpp                                     #CIDELETE
+      #env: docker_tag="NODOCKER" TARGET=apidoc          #CIDELETE
+      #git:                                              #CIDELETE
+        #submodules: false                               #CIDELETE
 
-    - os: linux
-      sudo: required
-      dist: trusty
-      language: cpp
-      compiler: gcc
-      env: TARGET=linux_gcc CONAN_COMPILER='gcc' CONAN_COMPILER_VERSION='6.3'
 
-    - os: linux
-      sudo: required
-      dist: trusty
-      env: TARGET=apidoc
-      # We check for gcc when deciding to deploy: so this is only an indicator that we want to deploy this branch.
-      language: cpp
-      compiler: gcc
-      git:
-        submodules: false
+    # We run the following jobs in ci-prebuilds:
+    # Our main compilers we run tests for
+    #CI - os: linux
+      #CI dist: trusty
+      #CI sudo: required
+      #CI language: cpp
+      #CI compiler: gcc
+      #CI services:
+        #CI - docker
+      #CI env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="7.2" TARGET=linux_gcc docker_tag="gcc070clang040" NIGHTLY="conan"
 
-    - os: linux
-      sudo: required
-      dist: trusty
-      env: TARGET=new_version_tagger
-      git:
-        submodules: false
-      branches:
-        only:
-          - master
+    #CI - os: linux
+      #CI dist: trusty
+      #CI sudo: required
+      #CI language: cpp
+      #CI compiler: clang
+      #CI services:
+        #CI - docker
+      #CI env: CMAKE_CC="clang-4.0" CMAKE_CXX="clang++-4.0" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="4.0" TARGET=linux_clang docker_tag="optimization" NIGHTLY="conan"
+
+    # Older compilers we compile Conan packages for, to speed things up for other people
+    #CI - os: linux
+      #CI dist: trusty
+      #CI sudo: required
+      #CI language: cpp
+      #CI compiler: gcc
+      #CI services:
+        #CI - docker
+      #CI env: CMAKE_CC="gcc-6" CMAKE_CXX="g++-6" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="6.3" TARGET=linux_gcc docker_tag="optimization" NIGHTLY="conan"
+
+    #CI - os: linux
+      #CI dist: trusty
+      #CI sudo: required
+      #CI language: cpp
+      #CI compiler: gcc
+      #CI services:
+        #CI - docker
+      #CI env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="5.4" TARGET=linux_gcc docker_tag="legacy" NIGHTLY="conan"
+
+    #CI - os: linux
+      #CI dist: trusty
+      #CI sudo: required
+      #CI language: cpp
+      #CI compiler: clang
+      #CI services:
+        #CI - docker
+      #CI env: CMAKE_CC="clang-3.9" CMAKE_CXX="clang++-3.9" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="3.9" TARGET=linux_clang docker_tag="legacy"  NIGHTLY="conan"
+
+    #CI - os: linux
+      #CI dist: trusty
+      #CI sudo: required
+      #CI language: cpp
+      #CI compiler: clang
+      #CI services:
+        #CI - docker
+      #CI env: CMAKE_CC="clang-3.8" CMAKE_CXX="clang++-3.8" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="3.8" TARGET=linux_clang docker_tag="legacy" NIGHTLY="conan"
+
+    #- os: osx
+      #sudo: false
+      #osx_image: xcode8
+      #language: cpp
+      #compiler: clang
+      #env: docker_tag="NODOCKER" compiler=clang TARGET="osx" CMAKE_FLAGS="-DCMAKE_CXX_COMPILER=clang++-3.9 -DCMAKE_C_COMPILER=clang-3.9 -DBUILD_ALL=1"
+
+  #CI fast_finish: true # don't wait for allow_failures to fail, gives faster response
+  #allow_failures:
+    #- os: osx
+
 
 before_install:
-  - bash tool/travis.sh target_before_install
+  # Get our CI Docker image
+  - if ! [[ "${docker_tag}" == 'NODOCKER' ]]; then
+        sudo docker pull inexorgame/ci-docker':'${docker_tag} ;
+    fi
 
 script:
-  - bash tool/travis.sh target_script
+  - if [ "${conan_prebuilds}" == "true" ]; then
+      set -e ;
+      bash ./tool/travis_conditional_conan_package_generating.sh ;
+    else
+      echo "${conan_prebuilds}" ;
+    fi
+  - if [ "${GLOBAL_NIGHTLY}" == "false" ]; then
+      NIGHTLY="false";
+    fi
+  - if [ "${GLOBAL_NIGHTLY}" == "conan" ]; then
+      NIGHTLY_USER="${CONAN_USER}";
+      NIGHTLY_PASSWORD="${CONAN_PASSWORD}";
+    else
+      NIGHTLY_USER="${FTP_USER}";
+      NIGHTLY_PASSWORD="${FTP_PASSWORD}";
+    fi
+  - if ! [[ "${docker_tag}" == "NODOCKER" ]]; then
+    sudo docker run -v $(pwd)':'/inexor --net=host -it inexorgame/ci-docker':'${docker_tag} /inexor/${RELATIVE_PATH}tool/travis.sh target_script /${RELATIVE_PATH} ${TARGET} ${CONAN_COMPILER} ${CONAN_COMPILER_VERSION} ${CMAKE_CC} ${CMAKE_CXX} ${TRAVIS_COMMIT} ${TRAVIS_BRANCH} ${TRAVIS_JOB_NUMBER} ${NIGHTLY} ${NIGHTLY_USER} ${NIGHTLY_PASSWORD} ${FTP_DOMAIN} ${TRAVIS_TAG} ${TRAVIS_PULL_REQUEST} ${TRAVIS_REPO_SLUG};
+    fi
+  - if [ "${TARGET}" == "new_version_tagger" ]; then
+        bash ./tool/travis.sh target_script /${RELATIVE_PATH} ${TARGET} ${CONAN_COMPILER} ${CONAN_COMPILER_VERSION} ${CMAKE_CC} ${CMAKE_CXX} ${TRAVIS_COMMIT} ${TRAVIS_BRANCH} ${TRAVIS_JOB_NUMBER} ${NIGHTLY} ${NIGHTLY_USER} ${NIGHTLY_PASSWORD} ${FTP_DOMAIN} ${TRAVIS_TAG} ${TRAVIS_PULL_REQUEST} ${TRAVIS_REPO_SLUG};
+    fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+      bash tool/travis.sh target_before_install;
+    fi
 
-after_success:
-  - bash tool/travis.sh target_after_success
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       compiler: clang                                    #CIDELETE
       services:                                          #CIDELETE
         - docker                                         #CIDELETE
-      env: CMAKE_CC="clang-4.0" CMAKE_CXX="clang++-4.0" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="4.0" TARGET=linux_clang docker_tag="optimization" NIGHTLY="true" #CIDELETE
+      env: CMAKE_CC="clang-4.0" CMAKE_CXX="clang++-4.0" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="4.0" TARGET=linux_clang docker_tag="ubuntu-artful-clang040" NIGHTLY="true" #CIDELETE
     - os: linux                                          #CIDELETE
       dist: trusty                                       #CIDELETE
       sudo: required                                     #CIDELETE
@@ -50,7 +50,7 @@ jobs:
       compiler: gcc                                      #CIDELETE
       services:                                          #CIDELETE
         - docker                                         #CIDELETE
-      env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="7.2" TARGET=linux_gcc docker_tag="gcc070clang040" NIGHTLY="true" #CIDELETE
+      env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="7.2" TARGET=linux_gcc docker_tag="ubuntu-artful-gcc07" NIGHTLY="true" #CIDELETE
     - stage: "Create GitHub Tag"                         #CIDELETE
       if: branch = master AND tag is blank AND fork is false AND type != pull_request #CIDELETE
       os: linux                                          #CIDELETE
@@ -81,7 +81,7 @@ jobs:
       #CI compiler: gcc
       #CI services:
         #CI - docker
-      #CI env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="7.2" TARGET=linux_gcc docker_tag="gcc070clang040" NIGHTLY="conan"
+      #CI env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="7.2" TARGET=linux_gcc docker_tag="ubuntu-artful-gcc07" NIGHTLY="conan"
 
     #CI - os: linux
       #CI dist: trusty
@@ -90,7 +90,7 @@ jobs:
       #CI compiler: clang
       #CI services:
         #CI - docker
-      #CI env: CMAKE_CC="clang-4.0" CMAKE_CXX="clang++-4.0" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="4.0" TARGET=linux_clang docker_tag="optimization" NIGHTLY="conan"
+      #CI env: CMAKE_CC="clang-4.0" CMAKE_CXX="clang++-4.0" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="4.0" TARGET=linux_clang docker_tag="ubuntu-artful-clang040" NIGHTLY="conan"
 
     # Older compilers we compile Conan packages for, to speed things up for other people
     #CI - os: linux
@@ -100,7 +100,7 @@ jobs:
       #CI compiler: gcc
       #CI services:
         #CI - docker
-      #CI env: CMAKE_CC="gcc-6" CMAKE_CXX="g++-6" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="6.3" TARGET=linux_gcc docker_tag="optimization" NIGHTLY="conan"
+      #CI env: CMAKE_CC="gcc-6" CMAKE_CXX="g++-6" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="6.3" TARGET=linux_gcc docker_tag="ubuntu-artful-gcc06" NIGHTLY="conan"
 
     #CI - os: linux
       #CI dist: trusty
@@ -109,7 +109,7 @@ jobs:
       #CI compiler: gcc
       #CI services:
         #CI - docker
-      #CI env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="5.4" TARGET=linux_gcc docker_tag="legacy" NIGHTLY="conan"
+      #CI env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CONAN_COMPILER="gcc" CONAN_COMPILER_VERSION="5.4" TARGET=linux_gcc docker_tag="ubuntu-zesty-gcc054" NIGHTLY="conan"
 
     #CI - os: linux
       #CI dist: trusty
@@ -118,7 +118,7 @@ jobs:
       #CI compiler: clang
       #CI services:
         #CI - docker
-      #CI env: CMAKE_CC="clang-3.9" CMAKE_CXX="clang++-3.9" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="3.9" TARGET=linux_clang docker_tag="legacy"  NIGHTLY="conan"
+      #CI env: CMAKE_CC="clang-3.9" CMAKE_CXX="clang++-3.9" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="3.9" TARGET=linux_clang docker_tag="ubuntu-zesty-clang039"  NIGHTLY="conan"
 
     #CI - os: linux
       #CI dist: trusty
@@ -127,7 +127,7 @@ jobs:
       #CI compiler: clang
       #CI services:
         #CI - docker
-      #CI env: CMAKE_CC="clang-3.8" CMAKE_CXX="clang++-3.8" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="3.8" TARGET=linux_clang docker_tag="legacy" NIGHTLY="conan"
+      #CI env: CMAKE_CC="clang-3.8" CMAKE_CXX="clang++-3.8" CONAN_COMPILER="clang" CONAN_COMPILER_VERSION="3.8" TARGET=linux_clang docker_tag="ubuntu-zesty-clang038" NIGHTLY="conan"
 
     #- os: osx
       #sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,46 @@
+###########################
+####### README FIRST! #####
+###########################
+# This file should only be edited in our main repository (code)
+# You are doing something wrong
+# if you are trying to edit this file in ci-prebuilds.
+#
+# Our automation is grabbing the version of this file from our main repository
+# and commit it with automatic changes to ci-prebuilds
+# and only when Conan dependencies are actually changed
+# in order to not cause unnecessary rebuilds.
+#
+# The ci-prebuilds version will have un-comment every line starting with #CI(followed by an empty space)
+# e.g. #CI echo this only gets executed in ci-prebuilds
+#
+# The ci-prebuilds version will have every line removed containing #CEDELETE
+# e.g. #CIDELETE this line is not visible in ci-prebuilds aka. won't get executed
+#
+
 version: 0.{build}
 clone_depth: 1
-clone_folder: C:\projects\inexor-game
+clone_folder: C:\projects\inexorgame
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
 # Maximum number of concurrent jobs for the project
-max_jobs: 2
+max_jobs: 4
+
+# https://www.appveyor.com/docs/build-environment/#build-worker-images
+image: Visual Studio 2017
+
+environment:
+    # VS VERSION IN CMAKE STYLE
+    matrix:
+      - VSVERSION: "15 2017"
+      - VSVERSION: "14 2015"
 
 platform:
- # - Win32
   - x64
+  #CI - Win32
 
 configuration:
+  #CI - Release
   - Debug
-  - Release
 
 # scripts that are called at very beginning, before repo cloning
 init:
@@ -22,32 +50,44 @@ init:
 # scripts that run after cloning repository
 install:
   - cmd: python -m pip install conan
-  - cmd: set "MAIN_FOLDER=C:\projects\inexor-game"
+  - cmd: set "MAIN_FOLDER=C:\projects\inexorgame\%RELATIVE_PATH%"
   - cmd: cd %MAIN_FOLDER%
-  - cmd: git submodule update --init
-  # set INEXOR_VERSION (used in cmakes package creation process) based on the last tag found.
+  - cmd: git submodule update --init --recursive
+  - cmd: set VSVERSIONSHORT=%VSVERSION:~0,2%
+   # set INEXOR_VERSION (used in cmakes package creation process) based on the last tag found.
   - cmd: if "%APPVEYOR_REPO_TAG%"=="true" ( set "INEXOR_VERSION=%APPVEYOR_REPO_TAG_NAME%" )
   - cmd: if "%APPVEYOR_REPO_TAG%"=="false" ( set "INEXOR_VERSION=development" )
 
 # scripts to run before build
 before_build:
-  - cmd: cd C:\projects\inexor-game
+  # Fix detection of VS 2017 by e.g. OpenSSL
+  - cmd: set "VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\"
+  - cmd: if "%VSVERSION%"=="15 2017" if "%platform%"=="x64" ( "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" )
+  - cmd: if "%VSVERSION%"=="15 2017" if "%platform%"=="Win32" ( "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsamd64_x86.bat" )
+
+  - cmd: cd %MAIN_FOLDER%
   - cmd: md build
   - cmd: cd build
+
   # We generate project files for Visual Studio 14 2015 only atm.
-  - cmd: if "%platform%"=="Win32" ( set "CMAKE_GENERATOR_NAME=Visual Studio 14 2015" && set "arch_str=x86" )
-  - cmd: if "%platform%"=="x64" ( set "CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64" && set "arch_str=x86_64")
+  - cmd: if "%platform%"=="Win32" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION%" && set "arch_str=x86" )
+  - cmd: if "%platform%"=="x64" ( set "CMAKE_GENERATOR_NAME=Visual Studio %VSVERSION% Win64" && set "arch_str=x86_64")
   - cmd: if %configuration%==Debug (set "runtime_str=MTd")else (set "runtime_str=MT")
-  - cmd: set "args=-DBUILD_CLIENT=1 -DBUILD_SERVER=1 -DBUILD_MASTER=1 -DBUILD_TEST=1 -DCREATE_PACKAGE=1"
-  # Only deploy a bundle with the media folder if the branch is master (and its not a pr)(and its a Release build):
-#  - cmd: if "%configuration%"=="Release" if "%APPVEYOR_REPO_BRANCH%"=="master" if defined APPVEYOR_PULL_REQUEST_NUMBER set "args=%args% -DPACKAGE_INCLUDE_MEDIA=1"
+
+  - cmd: set "args=-DBUILD_CLIENT=1 -DBUILD_SERVER=1 -DBUILD_TEST=1 -DCREATE_PACKAGE=1"
+
   - cmd: conan remote add inexor https://api.bintray.com/conan/inexorgame/inexor-conan --insert
-  - cmd: conan install .. --scope build_all=1 --scope create_package=1 --build=missing -s compiler="Visual Studio" -s compiler.version=14 -s compiler.runtime=%runtime_str% -s arch=%arch_str% -s build_type=%configuration%
-  - cmd: cmake .. -G "%CMAKE_GENERATOR_NAME%" %args% -DCPACK_GENERATOR="ZIP"
-  #"NSIS;7Z"
+  - cmd: conan remote add community https://api.bintray.com/conan/conan-community/conan --insert 3
+
+  - cmd: if "%GLOBAL_NIGHTLY%"=="conan" ( conan install .. --scope build_all=1 --build -s compiler="Visual Studio" -s compiler.version=%VSVERSIONSHORT% -s compiler.runtime=%runtime_str% -s arch=%arch_str% -s build_type=%configuration% ) else ( conan install .. --scope build_all=1 --scope create_package=1 --build=missing -s compiler="Visual Studio" -s compiler.version=%VSVERSIONSHORT% -s compiler.runtime=%runtime_str% -s arch=%arch_str% -s build_type=%configuration% )
+  - cmd: if "%GLOBAL_NIGHTLY%"=="conan" ( conan user --password "%CONAN_PASSWORD%" -r inexor "%CONAN_USER%" )
+  - cmd: if "%GLOBAL_NIGHTLY%"=="conan" ( conan upload --all -r inexor --retry 3 --retry_wait 10 --confirm "*stable*" )
+  - cmd: if "%GLOBAL_NIGHTLY%"=="true" ( cmake .. -G "%CMAKE_GENERATOR_NAME%" %args% -DCPACK_GENERATOR="ZIP" ) else ( cmake .. -G "%CMAKE_GENERATOR_NAME%" %args% )
+#"NSIS;7Z"
+
 
 build:
-  project: C:\projects\inexor-game\build\PACKAGE.vcxproj
+  project: "%MAIN_FOLDER%build\\PACKAGE.vcxproj"
   # enable MSBuild parallel builds
   parallel: true
 
@@ -78,4 +118,4 @@ deploy:
       configuration: Release
 
 test_script:
-  - C:\projects\inexor-game\build\bin\unit_tests.exe
+  - C:\projects\inexorgame\%RELATIVE_PATH%build\bin\unit_tests.exe

--- a/cmake/compile_flags_and_defs.cmake
+++ b/cmake/compile_flags_and_defs.cmake
@@ -2,7 +2,7 @@
 ## Note: This file needs to be included **after** platform_detection.cmake.
 
 
-## GCC and CLang 
+## GCC and CLang
 list(APPEND GNU_OR_CLANG_COMPILER_FLAGS
   -fomit-frame-pointer            # Don't keep the frame pointer for functions that don't need one
   -fno-strict-aliasing            # Avoid assumptions regarding non-aliasing of objects of different types
@@ -10,7 +10,7 @@ list(APPEND GNU_OR_CLANG_COMPILER_FLAGS
   -pipe                           # Use pipes rather than temporary files for communication between build stages
   -Wall                           # Enable all warnings
   -Wno-switch                     # Execpt Warnings for missing switch cases
-  -Wno-deprecated-declarations    # 
+  -Wno-deprecated-declarations    #
   -Wno-missing-braces             #
   -fdiagnostics-show-option       # Show Warning IDs
   -g                              # Generate debug information
@@ -170,9 +170,8 @@ if(OS_WINDOWS)
   add_definitions(-DWIN32 -D_WIN32 -D_WINDOWS -DWINDOWS -DNOMINMAX -D_WIN32_WINNT=0x0600 -D_MATH_DEFINES_DEFINED -DWIN32_LEAN_AND_MEAN )
   if(X64)
     add_definitions(-DWIN64)
-  endif()	
+  endif()
 endif()
 
 get_directory_property(DEFINITIONS              COMPILE_DEFINITIONS)
 message(STATUS "Platform definitions:           ${DEFINITIONS}")
-

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake
-import os, dependencies, multiprocessing
+import dependencies
+
 
 class InexorConan(ConanFile):
     license = "ZLIB"
@@ -25,16 +26,16 @@ class InexorConan(ConanFile):
             args += ["-DBUILD_MASTER=1"]
         if self.scope.create_package:
             args += ["-DCREATE_PACKAGE=1"]
-        cmake = CMake(self.settings)
+        cmake = CMake(self)
         self.run('cmake "{}" {} {}'.format(self.conanfile_directory, cmake.command_line, ' '.join(args)))
         self.run('cmake --build . --target install {}'.format(cmake.build_config))
         if self.scope.create_package:
             self.run('cmake --build . --target package_debug {}'.format(cmake.build_config))
 
     def imports(self):
-        self.copy("*.dll", dst="bin", src="bin") # From bin to bin
-        self.copy("*.so*", dst="bin", src="lib") # From lib to bin
-        self.copy("*.dylib*", dst="bin", src="lib") # From lib to bin
-        self.copy("*.bin", dst="bin", src="bin") # From bin to bin
-        self.copy("*.dat", dst="bin", src="bin") # From bin to bin
-        self.copy("*.pak", dst="bin", src="bin") # From bin to bin
+        self.copy("*.dll", dst="bin", src="bin")  # From bin to bin
+        self.copy("*.so*", dst="bin", src="lib")  # From lib to bin
+        self.copy("*.dylib*", dst="bin", src="lib")  # From lib to bin
+        self.copy("*.bin", dst="bin", src="bin")  # From bin to bin
+        self.copy("*.dat", dst="bin", src="bin")  # From bin to bin
+        self.copy("*.pak", dst="bin", src="bin")  # From bin to bin

--- a/dependencies.py
+++ b/dependencies.py
@@ -1,6 +1,6 @@
 requires = (("InexorGlueGen/0.6.0alpha@inexorgame/stable"),
             ("Protobuf/3.1.0@inexorgame/stable"),
-            ("gRPC/1.1.0-dev@inexorgame/stable"),
+            ("gRPC/1.1.0@inexorgame/stable"),
             ("doxygen/1.8.13@inexorgame/stable"),
             ("Boost/1.64.0@lasote/stable"),
             ("RapidJSON/1.0.2@inexorgame/stable"),

--- a/tool/README.md
+++ b/tool/README.md
@@ -1,4 +1,5 @@
 # Tools
 
-This directory contains tool files for Inexor. Currently there are files for our CI.
-Also you can use the create_visual_studio201x_project.bat files to easily compile Inexor with Visual Studio.
+This directory contains tool files for Inexor. Currently:
+  * scripts for our CI
+  * scripts for easy building with Visual Studio

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -264,14 +264,21 @@ if [[ $CC == gcc* ]]; then
 fi
 
 
-if [ -z "$2" ]; then
-  export gitroot="/inexor"
+if [[ $TARGET == new_version_tagger ]]; then
+  # we don't run this target within a docker container
+  # i.e. we don't need to switch the directory
+  # to be within our git repository clone
+  export gitroot="."
 else
-  # this makes it possible to run this script successfull
-  # even if doesn't get called from the root directory
-  # of THIS repository
-  # required to make inexor-game/ci-prebuilds working
-  export gitroot="/inexor/$2"
+  if [ -z "$2" ]; then
+    export gitroot="/inexor"
+  else
+    # this makes it possible to run this script successfull
+    # even if doesn't get called from the root directory
+    # of THIS repository
+    # required to make inexor-game/ci-prebuilds working
+    export gitroot="/inexor/$2"
+  fi
 fi
 
 self_pull_request && {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -2,10 +2,7 @@
 #
 # Structure
 # * Utility functions
-# * Installation target implementations
-# * Nightly build/APIDOC uploading
 # * Compiling and testing
-# * Targets as called by .travis.yml
 # * Main routine
 
 ## UTILITY FUNCTIONS #######################################
@@ -25,8 +22,7 @@ mkcd() {
   cd "$1"
 }
 
-# Check whether this travis job runs for the main repository
-# that is inexor-game/code
+# Check whether this travis job runs for the main repository (inexorgame/inexor-core)
 is_main_repo() {
   test "${TRAVIS_REPO_SLUG}" = "${main_repo}"
 }
@@ -70,75 +66,72 @@ need_new_tag() {
   fi
 }
 
-# upload remote_path local_path [local_paths]...
-#
-# Upload one or more files to nightly.inexor.org
-upload() {
-  # Fix an issue where upload directory gets specified by subsequent upload() calls
-  ncftpput -R -v -u "$FTP_USER" -p "$FTP_PASSWORD" nightly.inexor.org /linux/ "$@" || true
-}
-
 ## INSTALLATION ROUTINES ###################################
 
-install_additional_repos() {
-  echo -e "\ndeb http://archive.ubuntu.com/ubuntu zesty "{main,multiverse,universe,restricted} >> /etc/apt/sources.list
+build() {
+  (
+    mkcd "/tmp/inexor-build"
+
+    conan --version
+
+    conan remote add inexor https://api.bintray.com/conan/inexorgame/inexor-conan --insert
+    conan remote add community https://api.bintray.com/conan/conan-community/conan --insert 3
+
+    if test "$NIGHTLY" = conan; then
+      echo "executed conan install "$gitroot" --scope build_all=1 --build -s compiler=$CONAN_COMPILER -s compiler.version=$CONAN_COMPILER_VERSION -s compiler.libcxx=libstdc++11 -e CC=$CC -e CXX=$CXX"
+      conan install "$gitroot" --scope build_all=1 --build -s compiler="$CONAN_COMPILER" -s compiler.version="$CONAN_COMPILER_VERSION" -s compiler.libcxx="libstdc++11" -e CC="$CC" -e CXX="$CXX"
+    else
+      echo "executed conan install "$gitroot" --scope build_all=1 --scope create_package=1 --build=missing -s compiler=$CONAN_COMPILER -s compiler.version=$CONAN_COMPILER_VERSION -s compiler.libcxx=libstdc++11 -e CC=$CC -e CXX=$CXX"
+      conan install "$gitroot" --scope build_all=1 --scope create_package=1 --build=missing -s compiler="$CONAN_COMPILER" -s compiler.version="$CONAN_COMPILER_VERSION" -s compiler.libcxx="libstdc++11" -e CC="$CC" -e CXX="$CXX"
+    fi
+
+    conan build "$gitroot"
+
+    # workaround that CPack sometimes fails on linux to copy the file to the final directory from the intermediate dir..
+    local tempdir="/tmp/inexor-build/_CPack_Packages/Linux/ZIP/"
+    local zipname="Inexor-${last_tag}-Linux.zip"
+    local outputdir="/tmp/inexor-build/"
+    mv -f -v -u "${tempdir}${zipname}" "${outputdir}" || true
+  )
 }
 
-install_tool() {
-  apt-get -y -t trusty install ncftp
-}
-
-install_linux() {
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FB1BF5BF09FA0AB7
-
-  install_additional_repos
-  apt-get update
-
-
-  install_tool
-
-  apt-get -y -t zesty install --only-upgrade libfontconfig1 cmake
-  apt-get -y -t zesty install build-essential binutils nasm
-  python -m pip install conan
-}
-
-# Install routines for each target
-
-install_win64() {
-  install_additional_repos
-  apt-get update
-  install_tool
-  apt-get -y -t zesty install mingw-w64
-}
-install_win32() {
-  install_win64
-}
-install_linux_clang() {
-  install_linux
-  apt-get -y -t zesty install clang-3.9 binutils
-}
-install_linux_gcc() {
-  install_linux
-  apt-get -y -t zesty install gcc-6 g++-6
-}
-install_apidoc() {
-  apt-get update
-  install_tool
-  apt-get install -y -t trusty doxygen
-}
 
 install_new_version_tagger() {
   return 0
 }
 
-install_osx() {
-  # if you need sudo for some stuff here, you need to adjust travis.yml and target_before_install()
-  #brew install sdl2
-  exit 0
+
+run_tests() {
+  if contains "$TARGET" linux; then
+    "${bin}/unit_tests.exe"
+  else
+    echo >&2 "ERROR: UNKNOWN TRAVIS TARGET: ${TARGET}"
+    exit 23
+  fi
+}
+
+
+# ATTENTION:
+# Please USE the following naming format for any files uploaded to our distribution server
+# <BRANCHNAME>-<BUILDNUMBER>-<TARGET_NAME>.EXTENSION
+# where <PACKAGENAME> is NOT CONTAINING any -
+# correct: master-1043.2-linux_gcc.txt
+# correct: refactor-992.2-apidoc.hip
+# exception: master-latest-<TARGET_NAME>.zip
+# wrong: ...-linux_gcc-1043.2.zip
+
+## UPLOADING BUILDS AND THE APIDOC #################
+
+# upload remote_path local_path [local_paths]...
+#
+# Upload one or more files to our nightly or dependencies server
+# Variables are defined on the Travis website
+upload() {
+  # Fix an issue where upload directory gets specified by subsequent upload() calls
+  ncftpput -R -v -u "$FTP_USER" -p "$FTP_PASSWORD" "$FTP_DOMAIN" /linux/ "$@" || true
 }
 
 ## Automatic Creation of tags and generation of the doxygen documentation #################
-
 create_apidoc() {
   (
     local zipname="Inexor-${last_tag}-doc.zip"
@@ -160,14 +153,13 @@ incremented_version()
   local minor_version=`echo -e "${last_tag}" | sed "s/^[0-9]\+\.\(.*\)\.[0-9]\+.*$/\1/"`
   local patch_version=`echo -e "${last_tag}" | sed "s/^[0-9]\+\.[0-9]\+\.\(.[0-9]*\).*$/\1/"`
 
-
   local new_patch_version=$((patch_version+1))
   local new_version="$major_version.$minor_version.$new_patch_version@alpha"
   echo $new_version
 }
 
-# increment version and create a tag on github.
-# (each time we push to master)
+# increment version and create a tag on GitHub
+# each time we push to master, check are in travis.yml
 create_tag() {
   need_new_tag || {
     echo >&2 -e "===============\n" \
@@ -183,57 +175,32 @@ create_tag() {
     export new_version=$(incremented_version)
 
     git config --global user.email "travis@travis-ci.org"
-    git config --global user.name "Travis"
+    git config --global user.name "InexorBot"
 
-    git tag -a -m "automatic tag creation on push to master branch" "${new_version}"
+    git tag -a -m "Rolling release: automatic tag creation on push to master branch" "${new_version}"
     git push -q https://$GITHUB_TOKEN@github.com/inexorgame/inexor-core --tags
 
   else
     echo >&2 -e "===============\n" \
-      "Skipping tag creation, because this is \n" \
-      "not a direct commit to master.\n" \
-      "===============\n"
-      export new_version=$(incremented_version)
-      echo >&2 -e $new_version
+    "Skipping tag creation, because this is \n" \
+    "not a direct commit to master.\n" \
+    "===============\n"
+    export new_version=$(incremented_version)
+    echo >&2 -e $new_version
   fi
 }
 
-# ACTUALLY COMPILING AND TESTING INEXOR ####################
-
-build() {
-  (
-    mkcd "/tmp/inexor-build"
-    conan
-    conan remote add inexor https://api.bintray.com/conan/inexorgame/inexor-conan --insert
-    echo "executed conan install "$gitroot" --scope build_all=1 --scope create_package=1 --build=missing -s compiler=$CONAN_COMPILER -s compiler.version=$CONAN_COMPILER_VERSION -s compiler.libcxx=libstdc++11"
-    conan install "$gitroot" --scope build_all=1 --scope create_package=1  --build=missing -s compiler="$CONAN_COMPILER" -s compiler.version="$CONAN_COMPILER_VERSION" -s compiler.libcxx="libstdc++11"
-    conan build "$gitroot"
-
-    # workaround that CPack sometimes fails on linux to copy the file to the final directory from the intermediate dir..
-    local tempdir="/tmp/inexor-build/_CPack_Packages/Linux/ZIP/"
-    local zipname="Inexor-${last_tag}-Linux.zip"
-    local outputdir="/tmp/inexor-build/"
-    mv -f -v -u "${tempdir}${zipname}" "${outputdir}" || true
-  )
-}
-
-run_tests() {
-  if contains "$TARGET" linux; then
-    "${bin}/unit_tests.exe"
-  elif contains "$TARGET" win; then
-    echo >&2 "Sorry, win is not supported for testing yet."
-    exit 0
-  else
-    echo >&2 "ERROR: UNKNOWN TRAVIS TARGET: ${TARGET}"
-    exit 23
+# Upload nightly
+target_after_success() {
+  if test "$TARGET" != apidoc; then
+    if test "$NIGHTLY" = conan; then
+        # Upload all conan packages to our Bintray repository
+        conan user -p "${NIGHTLY_PASSWORD}" -r inexor "${NIGHTLY_USER}"
+        set -f
+        conan upload --all --force -r inexor --retry 3 --retry_wait 10 --confirm "*stable*"
+        set +f
+    fi
   fi
-}
-
-## TARGETS CALLED BY TRAVIS ################################
-
-target_before_install() {
-  sudo "$script" install_"$TARGET"
-  exit 0
 }
 
 target_script() {
@@ -244,31 +211,78 @@ target_script() {
   else
     build
     run_tests
+    target_after_success
   fi
-  exit 0
-}
-
-# Upload nightly
-target_after_success() {
- # if test "$TARGET" != apidoc; then
- #   external_pull_request || true
- # fi
   exit 0
 }
 
 ## MAIN ####################################################
 
+# this makes the entire script fail if one commands fail
 set -e
 
 script="$0"
 tool="`dirname "$0"`"
 code="${tool}/.."
 bin="${code}/bin"
+TARGET="$3"
+#CMAKE_FLAGS="$4"
+CONAN_COMPILER="$4"
+CONAN_COMPILER_VERSION="$5"
+export CC="$6"
+export CXX="$7"
 
-export main_repo="inexor-game/code"
-export branch="$TRAVIS_BRANCH" # The branch we're on
-export jobno="$TRAVIS_JOB_NUMBER" # The job number
-export commit="${TRAVIS_COMMIT}"
+export commit="$8"
+export branch="$9" # The branch we're on
+export jobno="${10}" # The job number
+# Nightly is either true, false or conan
+NIGHTLY="${11}"
+NIGHTLY_USER="${12}"
+NIGHTLY_PASSWORD="${13}"
+FTP_DOMAIN="${14}"
+if test "${15}" != NO_TAG; then
+  TRAVIS_TAG=${15}
+fi
+TRAVIS_PULL_REQUEST="${16}"
+TRAVIS_REPO_SLUG="${17}"
+
+
+# Name of this build
+export build="$(echo "${branch}-${jobno}" | sed 's#/#-#g')-${TARGET}"
+export main_repo="inexorgame/inexor-core"
+
+# Workaround Boost.Build problem to not be able to found Clang
+if [[ $CC == clang* ]]; then
+  sudo ln -sf /usr/bin/${CC} /usr/bin/clang
+  sudo ln -sf /usr/bin/${CXX} /usr/bin/clang++
+fi
+
+# Just to make sure that no package uses the wrong GCC version...
+if [[ $CC == gcc* ]]; then
+  sudo ln -sf /usr/bin/${CC} /usr/bin/gcc
+  sudo ln -sf /usr/bin/${CXX} /usr/bin/gcc++
+fi
+
+
+if [ -z "$2" ]; then
+  export gitroot="/inexor"
+else
+  # this makes it possible to run this script successfull
+  # even if doesn't get called from the root directory
+  # of THIS repository
+  # required to make inexor-game/ci-prebuilds working
+  export gitroot="/inexor/$2"
+fi
+
+self_pull_request && {
+  echo >&2 -e "Skipping build, because this is a pull " \
+    "request with a branch in the main repo.\n"         \
+    "This means, there should already be a CI job for " \
+    "this branch. No need to do things twice."
+  exit 0
+}
+
+cd "$gitroot"
 
 # Tags do not get fetched from travis usually.
 git fetch origin 'refs/tags/*:refs/tags/*'
@@ -286,17 +300,4 @@ need_new_tag && {
   export INEXOR_VERSION=$(incremented_version)
 }
 
-# Name of this build
-export build="$(echo "${branch}-${jobno}" | sed 's#/#-#g')-${TARGET}"
-export gitroot="$TRAVIS_BUILD_DIR"
-
-self_pull_request && {
-  echo >&2 -e "Skipping build, because this is a pull " \
-    "request with a branch in the main repo.\n"         \
-    "This means, there should already be a ci job for " \
-    "this branch. No need to do things twice."
-  exit 0
-}
-
-cd "$gitroot"
 "$@"  # Call the desired function

--- a/tool/travis_conditional_conan_package_generating.sh
+++ b/tool/travis_conditional_conan_package_generating.sh
@@ -15,11 +15,11 @@ set -e
 # Making sure we NEVER execute anything of this for pull requests as this could be a huge security risk
 if [[ "${TRAVIS_PULL_REQUEST}" != false ]]; then
     echo "We don't build Conan packages for pull requests for security reasons."
-    # exit 0
+    exit 0
 fi
 
 
-if ! [[ "${TRAVIS_BRANCH}" == "croydon/dockerization+conan-packages" ]]; then
+if ! [[ "${TRAVIS_BRANCH}" == "master" ]]; then
     echo "This isn't the master branch"
     exit 0
 fi
@@ -50,8 +50,8 @@ echo "Update submodule in ci-prebuilds"
 cd inexor
 
 git fetch --all
-git checkout croydon/dockerization+conan-packages
-git reset --hard origin/croydon/dockerization+conan-packages
+git checkout master
+git reset --hard origin/master
 cd ../
 
 

--- a/tool/travis_conditional_conan_package_generating.sh
+++ b/tool/travis_conditional_conan_package_generating.sh
@@ -1,0 +1,82 @@
+#! /bin/bash
+# This file checks if we change files, which are important for mass building for Conan packages
+# If they changed we are going to trigger a mass building
+# We are doing this by updating the submodule in inexor-game/ci-prebuilds invoking thereby Travis/AppVeyor processes
+# We also commit possible changes in appveyor.yml and .travis.yml
+# In both, appveyor.yml and .travis.yml, lines with #CI (followed by a space) are getting un-comment
+# In both, appveyor.yml and .travis.yml, lines with #CIDELETE are getting completely removed
+
+
+# TODO: support for branches with conan- instead of only master to test mass building of packages easily (maybe)
+
+# this makes the entire script fail if one commands fail
+set -e
+
+# Making sure we NEVER execute anything of this for pull requests as this could be a huge security risk
+if [[ "${TRAVIS_PULL_REQUEST}" != false ]]; then
+    echo "We don't build Conan packages for pull requests for security reasons."
+    # exit 0
+fi
+
+
+if ! [[ "${TRAVIS_BRANCH}" == "croydon/dockerization+conan-packages" ]]; then
+    echo "This isn't the master branch"
+    exit 0
+fi
+
+# Check if important files did change in the last commit (the commit we are checking out)
+echo "Filtered git diff output:"
+echo "$(git diff --name-only ${TRAVIS_COMMIT}^ -- dependencies.py)"
+
+if [[ "$(git diff --name-only ${TRAVIS_COMMIT}^ -- dependencies.py)" == "" ]]; then
+    echo "No changes found in Conan dependencies!"
+    exit 0
+fi
+
+echo "Changes found in Conan dependencies!"
+echo "Configure git"
+
+cd ..
+git clone --recursive https://github.com/inexorgame/ci-prebuilds.git "ci-prebuilds"
+cd "ci-prebuilds"
+
+git checkout master
+
+git config user.name ${GITHUB_BOT_NAME}
+git config user.email ${GITHUB_BOT_EMAIL}
+
+
+echo "Update submodule in ci-prebuilds"
+cd inexor
+
+git fetch --all
+git checkout croydon/dockerization+conan-packages
+git reset --hard origin/croydon/dockerization+conan-packages
+cd ../
+
+
+echo "Get possible updates of appveyor.yml"
+sed 's/#CI //' inexor/appveyor.yml > appveyor.yml
+sed --in-place '/#CIDELETE/d' appveyor.yml
+
+echo "Get possible updates of .travis.yml"
+sed 's/#CI //' inexor/.travis.yml > .travis.yml
+sed --in-place '/#CIDELETE/d' .travis.yml
+
+echo "Create a commit"
+git add -A
+git commit -am '[bot] Building and uploading Conan dependencies!
+Triggered by: https://github.com/inexorgame/inexor-core/commit/'${TRAVIS_COMMIT}
+
+
+
+git config credential.helper "store --file=.git/credentials"
+echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
+
+
+echo "Push commit"
+git push
+
+
+echo "Mass building of Conan packages is on its way!"
+exit 0


### PR DESCRIPTION
## DON'T EVEN DARE TO MERGE THIS IF YOU ARE NOT ME

Using Docker in our CI has several advantages, including but not limited to:
 * being independent from our CI hoster, e.g. Travis has very often old software, we can pretty much use every version of Ubuntu or any other Linux based OS, including any compatible packages for these OS/versions
 * make LOCAL CI debugging A LOT easier, the only thing needed is Docker installed locally, then you have pretty much 100% the same testing environment
 * being able to generate Conan packages and test building + running tests on more compiler/version than ever before + being able to expend it easily 

Things I need to do before(?) merging:
 * [x] check if git tag creating is still working
 * [ ] check if Windows Conan packages are fine
 * [x] install conan-community as another repository (to pull in recipes we actually use from there as well)
 * [x] **RENAME BRANCH NAMES FOR MASTER**

Things I would like to do at some point after merging this:
 * get all Conan packages we use in our own Conan repository (or this gets a problem when we use packages which aren't in our repo or conan center or conan transit)
   * automate this steps, which additional information writing in dependencies.py
   * => auto import of new (version of) packages from external Conan recipes we use (+ as a consequences packages generating)
 * making local debugging even easier (e.g. right now you would need to give a lot of parameters to the .sh file in order to run it successfully)
 * add more compiler/versions (new versions get released quicker than characters can get killed off in Game Of Thrones)

This is not perfect yet but already waaaaay better than the currect setup, so let's finally merge this.

PS: Sorry for typos and gramma, it's late 😄 


