### PR TITLE
Fix linux build

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -251,6 +251,8 @@ function(add_app exe)
   if(MSVC)
     set_property(TARGET ${exe} PROPERTY FOLDER "executables")
   endif()
+
+  target_link_libraries(${exe} ${CONAN_LIBS})
 endfunction()
 
 # USAGE: add_lib(modulename)


### PR DESCRIPTION
Fixes:
```
/home/aschaeffer/.conan/data/gRPC/1.1.0-dev/inexorgame/stable/package/e90db5771a0284224fb7e8a09afcb6bd9088ffc2/lib/libgrpc++.a(server_builder.cc.o): In Funktion grpc::ServerBuilder::InternalAddPluginFactory(std::unique_ptr<grpc::ServerBuilderPlugin, std::default_delete<grpc::ServerBuilderPlugin> > (*)())': server_builder.cc:(.text+0x886): Nicht definierter Verweis aufgpr_once_init'
/home/aschaeffer/.conan/data/gRPC/1.1.0-dev/inexorgame/stable/package/e90db5771a0284224fb7e8a09afcb6bd9088ffc2/lib/libgrpc++.a(server_builder.cc.o): In Funktion grpc::ServerBuilder::ServerBuilder()': server_builder.cc:(.text+0xa17): Nicht definierter Verweis aufgpr_cpu_num_cores'
server_builder.cc:(.text+0xaae): Nicht definierter Verweis auf gpr_once_init' server_builder.cc:(.text+0xca1): Nicht definierter Verweis aufgpr_cpu_num_cores'
/home/aschaeffer/.conan/data/gRPC/1.1.0-dev/inexorgame/stable/package/e90db5771a0284224fb7e8a09afcb6bd9088ffc2/lib/libgrpc++.a(server_cc.cc.o): In Funktion grpc::Server::Server(int, grpc::ChannelArguments*, std::shared_ptr<std::vector<std::unique_ptr<grpc::ServerCompletionQueue, std::default_delete<grpc::ServerCompletionQueue> >, std::allocator<std::unique_ptr<grpc::ServerCompletionQueue, std::default_delete<grpc::ServerCompletionQueue> > > > >, int, int, int)': server_cc.cc:(.text+0x2710): Nicht definierter Verweis aufgpr_once_init'
```