### PR TITLE
Hide cef_subprocess console from user

### DIFF
--- a/inexor/ui/cef_subprocess/CMakeLists.txt
+++ b/inexor/ui/cef_subprocess/CMakeLists.txt
@@ -2,6 +2,6 @@ set(mod cef_subprocess)
 string(TOUPPER ${mod} MOD)
 
 declare_module(${mod} .)
-add_app(${mod} ${${MOD}_MODULE_SOURCES} CONSOLE_APP)
+add_app(${mod} ${${MOD}_MODULE_SOURCES})
 
 require_ui(${mod})

--- a/inexor/ui/cef_subprocess/main.cpp
+++ b/inexor/ui/cef_subprocess/main.cpp
@@ -9,7 +9,11 @@
 
 #undef main
 
+#ifdef WIN32
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
+#else
 int main(int argc, char *argv[])
+#endif
 {
     setlocale(LC_ALL, "en_US.utf8");
     std::cout << "init: cef: cef_subprocess\n";

--- a/inexor/ui/cef_subprocess/main.cpp
+++ b/inexor/ui/cef_subprocess/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
 #ifdef WIN32
-    CefMainArgs main_args(GetModuleHandle(NULL));
+    CefMainArgs main_args(hInstance);
 #else
     const CefMainArgs main_args(argc, argv);
 #endif


### PR DESCRIPTION
In order to hide CEF's subprocess console windows from the user, we could use this simple fix.
See  #566 