### PR TITLE
fix(travis): Remove buggy Travis stage conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ core: &core
               - doxygen
         env: DOCKER="NODOCKER" TARGET="apidoc"
       - stage: "Create GitHub Tag"
-        if: branch = master AND tag is blank AND fork is false AND repo = head_repo AND type != pull_request
         os: linux
         sudo: false
         dist: trusty


### PR DESCRIPTION
The tag creation is protected by other checks already (see .travis.yml file down below).

The stage condition caused the complete removal of the stage from Travis builds.